### PR TITLE
Fix bug in loss for trees with one edge from leave to parent

### DIFF
--- a/better_mistakes/model/losses.py
+++ b/better_mistakes/model/losses.py
@@ -74,7 +74,7 @@ class HierarchicalLLLoss(torch.nn.Module):
                 self.weights[i, j] = get_label(weights[positions_edges[k]])
             for j, k in enumerate(edges_from_leaf[i][1:]):
                 self.onehot_den[i, leaf_indices[k], j] = 1.0
-            self.onehot_den[i, :, j + 1] = 1.0  # the last denominator is the sum of all leaves
+            self.onehot_den[i, :,  len(edges_from_leaf) - 1] = 1.0  # the last denominator is the sum of all leaves
 
     def forward(self, inputs, target):
         """


### PR DESCRIPTION
Hi there, thanks for making the code for this project public!

I think there may be a bug in the calculation of the hierarchical cross-entropy loss for the edge case of having only one edge between leaf and parent. Specifically, on this line https://github.com/fiveai/making-better-mistakes/blob/master/better_mistakes/model/losses.py#L77, `j+1` is used to fill in the last column. However, when `len(edges_from_leaf[i])` is 1, the loop for the denominator is never entered, so `j=0`, so `onehot_den_np[i, :, 1] = 1.0`. However, since there is only one leave, actually it should be `onehot_den_np[i, :, 0] = 1.0`. 

The bug can be fixed by changing line 77 to this:
````
self.onehot_den[i, :, len(edges_from_leaf[i]) - 1] = 1.0
````
 This should work in every case. Let me know if you agree with me. 